### PR TITLE
cross-spawn Gulp and catch errors

### DIFF
--- a/gulp/tasks.js
+++ b/gulp/tasks.js
@@ -1,0 +1,3 @@
+// tasks.js
+// ============================================================================
+// Gulp task file - blank, a placeholder for some real tasks.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,17 @@
+// gulpfile.js
+// ============================================================================
+/**  Rather than manage one giant configuration file responsible
+*    for creating multiple tasks, each task has been broken out into
+*    its own file in `/gulp`. Any files in that directory
+*    get automatically required below.
+*    To add a new task, simply add a new task file that directory.
+*    `/gulp/tasks.js` specifies the default set of
+*    tasks to run when you run `gulp`.
+*/
+
+var requireDir = require('require-dir')
+
+// Require all tasks in gulp/tasks, including subfolders
+requireDir('./gulp', {
+    recurse: true
+})

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
   },
   "homepage": "https://github.com/NHSLeadership/nhs-prototyping-kit#readme",
   "dependencies": {
+    "cross-spawn": "^5.0.0",
     "express": "4.13.3",
-    "nunjucks": "^2.5.2"
+    "gulp": "^3.9.1",
+    "nunjucks": "^2.5.2",
+    "require-dir": "^0.3.0"
   }
 }

--- a/start.js
+++ b/start.js
@@ -56,9 +56,9 @@ app.set('view engine', 'html')
 
 // Routes
 // ---------------------------------------------------------------------------
-// Import routes
 //
 
+// Import routes
 app.use(require('./app/routes'))
 
 
@@ -70,3 +70,26 @@ app.use(require('./app/routes'))
 app.listen(port);
 // Tell us it's started
 console.log('Server started on port', port);
+
+
+// Gulp
+// ---------------------------------------------------------------------------
+//
+
+// Requires to sport node async scripts
+var spawn = require('cross-spawn')
+// Colour set for errors
+process.env['FORCE_COLOR'] = 1
+
+// Gulp
+var gulp = spawn('gulp')
+
+// Catch errors
+gulp.stdout.pipe(process.stdout)
+gulp.stderr.pipe(process.stderr)
+process.stdin.pipe(gulp.stdin)
+
+// Report errors
+gulp.on('exit', function (code) {
+  console.log('gulp exited with code ' + code.toString())
+})


### PR DESCRIPTION
[refs #4] As we don't yet have any tasks, this will have:

- Grunt installed
- Grunt called
- A Grunt folder looked in for all our lovely scripts
- Error that there is no default task to run and exit without impacting the ExpressJS app